### PR TITLE
Make available in windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint:fix": "prettier --write \"@(*.css|*.js|*.json|src/**/*.@(ts|tsx))\"",
     "predev:gatsby": "npm run codegen",
     "dev:gatsby": "gatsby develop -H 0.0.0.0",
-    "dev:prettier": "onchange '@(*.css|*.js|*.json|*.ts|@(src|types)/**/*.@(ts|tsx))' -- prettier --write {{changed}}",
+    "dev:prettier": "onchange \"@(*.css|*.js|*.json|*.ts|@(src|types)/**/*.@(ts|tsx))\" -- prettier --write {{changed}}",
     "codegen": "graphql-codegen --config codegen.yml",
     "dev": "run-p dev:**"
   },


### PR DESCRIPTION
It resolves #26. 

Before this, there was errors when we run `npm run dev:prettier` in windows environment.
To run the command, we should use double quotations (`"`), not single quotation (`'`).