### PR TITLE
Auto refresh page

### DIFF
--- a/DEPLOYMENTS.tsv
+++ b/DEPLOYMENTS.tsv
@@ -1,3 +1,3 @@
-9c-fft	http://52.231.65.77:5000/graphql/
+9c-fft	http://52.231.74.24:31235/graphql
 9c-testnet	http://9c-testnet.planetarium.dev:31235/graphql/
 localhost	http://localhost:5000/graphql/

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -15,6 +15,8 @@ interface IndexPageProps {
   location: Location;
 }
 
+const POLL_INTERVAL = 2000;
+
 const IndexPage: React.FC<IndexPageProps> = ({ location }) => {
   const limit = 21;
   const [searchParams, setSearchParams] = useSearchParams(location);
@@ -44,7 +46,10 @@ const IndexPage: React.FC<IndexPageProps> = ({ location }) => {
           setExcludeEmptyTxs(!!checked);
         }}
       />
-      <BlockListComponent variables={{ offset, limit, excludeEmptyTxs }}>
+      <BlockListComponent
+        variables={{ offset, limit, excludeEmptyTxs }}
+        pollInterval={POLL_INTERVAL}
+      >
         {({ data, loading, error }) => {
           if (error) return <p>error!</p>;
 


### PR DESCRIPTION
Implements #37 

According to comments in issue and on discord, list will be refreshed if there are new items in it (new blocks added) or blocks with the same index have different hash (chain was swapped) - thus telling React to rerender the list.