### PR TITLE
Make account page show all txs and missing nonces

### DIFF
--- a/src/pages/account.tsx
+++ b/src/pages/account.tsx
@@ -37,23 +37,33 @@ const AccountPage: React.FC<AccountPageProps> = ({ location }) => {
             return <p>There are no transactions.</p>;
           }
 
-          const [
-            signedTransactions,
-            involvedTransactions,
-          ] = transactions.reduce(
-            (acc, tx) => {
-              if (tx.signer === queryString) {
-                acc[0].push(tx);
-              } else {
-                acc[1].push(tx);
-              }
-              return acc;
-            },
-            [[], []]
-          );
+          const signedTransactions: Transaction[] = [],
+            involvedTransactions: Transaction[] = [];
+          transactions.forEach(tx => {
+            if (tx.signer === queryString) {
+              signedTransactions.push(tx);
+            } else {
+              involvedTransactions.push(tx);
+            }
+          });
+
+          const missingNonces: number[] = [];
+          for (let i = 1; i < signedTransactions.length; ++i) {
+            const prevNonce = signedTransactions[i - 1].nonce;
+            const nonce = signedTransactions[i].nonce;
+            if (prevNonce === nonce - 1) continue;
+            for (
+              let missingNonce = prevNonce + 1;
+              missingNonce < nonce;
+              ++missingNonce
+            ) {
+              missingNonces.push(missingNonce);
+            }
+          }
 
           const numOfSigned = signedTransactions.length;
           const numOfInvolved = involvedTransactions.length;
+          const numOfMissingNonces = missingNonces.length;
 
           return (
             <>
@@ -80,6 +90,12 @@ const AccountPage: React.FC<AccountPageProps> = ({ location }) => {
                 />
               ) : (
                 <div>No transactions of this type</div>
+              )}
+              <h2>Missing Nonces: {numOfMissingNonces}</h2>
+              {numOfMissingNonces ? (
+                missingNonces.map(nonce => <p>{nonce}</p>)
+              ) : (
+                <div>No missing nonces.</div>
               )}
             </>
           );
@@ -175,7 +191,7 @@ const TransactionsList: React.FC<TxListProps> = ({ transactions }) => {
 
   return (
     <DetailsList
-      items={transactions.slice(0, -1)}
+      items={transactions}
       columns={columns}
       selectionMode={SelectionMode.none}
       getKey={tx => tx.id}


### PR DESCRIPTION
There was a bug `AccountPage` shows transactions except the last, not all transactions.

I fixed it. And I also made `AccountPage` show missing nonces of the signed transactions.

## Before
![image](https://user-images.githubusercontent.com/26626194/70770276-11e6a800-1db0-11ea-8556-454af3802019.png)

## After
![image](https://user-images.githubusercontent.com/26626194/70770295-27f46880-1db0-11ea-865f-5b6c958dd0f0.png)
