### PR TITLE
Fix output directory issue

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,12 +3,6 @@
 # Install deps
 npm install
 
-# Prepare build directory
-mkdir -p _site
-
-# Export CNAME
-echo "$DOMAIN" > _site/CNAME
-
 # Export endpoint uris to .env.production
 COUNT=0
 VAR_ENV="GRAPHQL_ENDPOINTS=["
@@ -22,5 +16,11 @@ done < DEPLOYMENTS.tsv
 VAR_ENV+="]";
 echo "$VAR_ENV" > ".env.production"
 
-# Then build Gatsby site
+# Then build Gatsby site into public (default path)
 npm run build
+
+# Export CNAME
+echo "$DOMAIN" > public/CNAME
+
+# Rename public to _site
+mv public _site


### PR DESCRIPTION
The current GitHub page setting expects `_site` is a base directory.
This patch renames Gatsby's default output directory(`public`) to `_site`.