### PR TITLE
Add isPermanent to generated paths

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -16,6 +16,7 @@ exports.createPages = ({ graphql, actions }) => {
       createPage({
         path: `${endpoint.name}/${file.path}`,
         component: path.resolve(`src/subpages/${file.name}`),
+        isPermanent: true,
         context: {
           endpoint,
         },


### PR DESCRIPTION
This fixes the routing issue for generated paths by `gatsby-node.js`.