### PR TITLE
Fix space-tab issue in DEPLOYMENTS.tsv

### DIFF
--- a/DEPLOYMENTS.tsv
+++ b/DEPLOYMENTS.tsv
@@ -1,4 +1,4 @@
 9c-alpha	https://dkgsnp0fti4zj.cloudfront.net/graphql/
 ground-zero	http://a1006a862183311ea98ec06ceb5d810e-1208435107.ap-northeast-2.elb.amazonaws.com:31235/graphql/
 localhost	http://localhost:5000/graphql/
-9c-internal https://d3n1gito7w9cnj.cloudfront.net/graphql/
+9c-internal	https://d3n1gito7w9cnj.cloudfront.net/graphql/

--- a/DEPLOYMENTS.tsv
+++ b/DEPLOYMENTS.tsv
@@ -1,4 +1,3 @@
 9c-alpha	https://dkgsnp0fti4zj.cloudfront.net/graphql/
-ground-zero	http://a1006a862183311ea98ec06ceb5d810e-1208435107.ap-northeast-2.elb.amazonaws.com:31235/graphql/
-localhost	http://localhost:5000/graphql/
 9c-internal	https://d3n1gito7w9cnj.cloudfront.net/graphql/
+localhost	http://localhost:5000/graphql/


### PR DESCRIPTION
I'm sorry but there was issue that there was *space*, not *tab* in *DEPLOYMENTS.tsv*.
So, in this pull request, I fixed it and removed disabled deployment (i.e., ground-zero).