### PR TITLE
Replace Intl format options for Browser compatibility

### DIFF
--- a/src/components/Timestamp.tsx
+++ b/src/components/Timestamp.tsx
@@ -6,9 +6,12 @@ interface TimestampProps {
 }
 const Timestamp: React.FC<TimestampProps> = ({ timestamp }) => {
   const date = new Date(timestamp);
-  const formatOptions: any = {
-    dateStyle: 'short',
-    timeStyle: 'short',
+  const formatOptions = {
+    hour: '2-digit',
+    minute: '2-digit',
+    year: '2-digit',
+    month: 'numeric',
+    day: 'numeric',
   };
   const now = new Date();
   let string = date.toLocaleString(undefined, formatOptions);
@@ -17,7 +20,8 @@ const Timestamp: React.FC<TimestampProps> = ({ timestamp }) => {
     now.getMonth() == date.getMonth() &&
     now.getDate() == date.getDate()
   ) {
-    string = date.toLocaleTimeString(undefined, formatOptions);
+    const { year, month, day, ...pickFormatOptions } = formatOptions;
+    string = date.toLocaleString(undefined, pickFormatOptions);
   }
   return (
     <time dateTime={date.toISOString()} title={date.toLocaleString()}>

--- a/src/components/Timestamp.tsx
+++ b/src/components/Timestamp.tsx
@@ -5,7 +5,7 @@ interface TimestampProps {
   timestamp: Scalars['DateTimeOffset'];
 }
 
-const formatOptions = {
+const formatOptions: Intl.DateTimeFormatOptions = {
   hour: '2-digit',
   minute: '2-digit',
   year: '2-digit',

--- a/src/components/Timestamp.tsx
+++ b/src/components/Timestamp.tsx
@@ -4,28 +4,33 @@ import React from 'react';
 interface TimestampProps {
   timestamp: Scalars['DateTimeOffset'];
 }
+
+const formatOptions = {
+  hour: '2-digit',
+  minute: '2-digit',
+  year: '2-digit',
+  month: 'numeric',
+  day: 'numeric',
+};
+
 const Timestamp: React.FC<TimestampProps> = ({ timestamp }) => {
   const date = new Date(timestamp);
-  const formatOptions = {
-    hour: '2-digit',
-    minute: '2-digit',
-    year: '2-digit',
-    month: 'numeric',
-    day: 'numeric',
-  };
   const now = new Date();
-  let string = date.toLocaleString(undefined, formatOptions);
   if (
     now.getFullYear() == date.getFullYear() &&
     now.getMonth() == date.getMonth() &&
     now.getDate() == date.getDate()
   ) {
-    const { year, month, day, ...pickFormatOptions } = formatOptions;
-    string = date.toLocaleString(undefined, pickFormatOptions);
+    const { year, month, day, ...timeStyle } = formatOptions;
+    return (
+      <time dateTime={date.toISOString()} title={date.toLocaleString()}>
+        {date.toLocaleString(undefined, timeStyle)}
+      </time>
+    );
   }
   return (
     <time dateTime={date.toISOString()} title={date.toLocaleString()}>
-      {string}
+      {date.toLocaleString(undefined, formatOptions)}
     </time>
   );
 };


### PR DESCRIPTION
Reference issue: #92

`dateStyle` and `timeStyle` options not yet implemented in some browsers.

I replace this options to output same result. (tested in chrome console):

<img width="487" alt="Screen Shot 2020-07-29 at 8 39 22 PM" src="https://user-images.githubusercontent.com/5278201/88795872-ab49b980-d1db-11ea-851b-e81e01fa32ba.png">
