### PR TITLE
Show action values with indent in transaction page

### DIFF
--- a/src/subpages/transaction.tsx
+++ b/src/subpages/transaction.tsx
@@ -93,7 +93,9 @@ const TransactionPage: React.FC<TransactionPageProps> = ({ location }) => {
                       <React.Fragment key={argument.key}>
                         <dt>{argument.key}</dt>
                         <dd>
-                          <code> {JSON.stringify(argument.value)} </code>
+                          <pre>
+                            <code> {JSON.stringify(argument.value, null, 2)} </code>
+                          </pre>
                         </dd>
                       </React.Fragment>
                     ))}


### PR DESCRIPTION
Used `JSON.stringfy` [`space` argument](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#The_space_argument) and `<pre />` tag.

| Before | After |
| :-: | :-: |
| <img width="386" alt="Screen Shot 2020-08-04 at 5 21 50 PM" src="https://user-images.githubusercontent.com/5278201/89271111-3bbe4900-d677-11ea-8ba2-834ad9ffe1ee.png">| <img width="526" alt="Screen Shot 2020-08-04 at 5 21 32 PM" src="https://user-images.githubusercontent.com/5278201/89271135-424cc080-d677-11ea-9a1e-305f387ec402.png"> |

## Sample transaction page

[`tx?e09bc5a3f5bc0bf5eec31ed0598fb4158cbdb6967a734fa4f6bdc78a9d346d91`](https://explorer.libplanet.io/9c-beta/transaction/?e09bc5a3f5bc0bf5eec31ed0598fb4158cbdb6967a734fa4f6bdc78a9d346d91)