### PR TITLE
Fix subpage routing

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -23,10 +23,12 @@ exports.createPages = async ({ graphql, actions }) => {
 
   GRAPHQL_ENDPOINTS.forEach(endpoint => {
     files.forEach(file => {
-      const generatedPath = file in remap ? remap[file] : path.parse(file).name;
+      const subPath = file in remap ? remap[file] : path.parse(file).name;
+      const pagePath =
+        subPath === '' ? `${endpoint.name}/` : `${endpoint.name}/${subPath}/`;
 
       createPage({
-        path: `${endpoint.name}/${generatedPath}`,
+        path: pagePath,
         component: path.resolve(`src/subpages/${file}`),
         isPermanent: true,
         context: {


### PR DESCRIPTION
This fixes an issue where path routing was not working properly when accessing a subpage directly.

For example, you can't access the transaction and account pages from the page below:
http://explorer.libplanet.io/9c-beta/block?c98d5d3ad38cd78dadfd6af5a73c6a9bd82654b241687c473f8f691143000000
