### PR TITLE
Set auto assign by github bot

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,11 @@
+addReviewers: true
+addAssignees: author
+
+reviewers:
+  - dahlia
+  - longfin
+  - limebell
+  - earlbread
+  - riemannulus
+  - moreal
+  - x86chi


### PR DESCRIPTION
> [code review assignment for your team - GitHub Docs](https://docs.github.com/en/github/setting-up-and-managing-organizations-and-teams/managing-code-review-assignment-for-your-team#configuring-code-review-assignment)

Upper feature is not woking in our repository. so I add config for [auto-assign](https://github.com/kentaro-m/auto-assign) github bot.