### PR TITLE
Add number of reviewers

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -9,3 +9,6 @@ reviewers:
   - riemannulus
   - moreal
   - x86chi
+
+numberOfReviewers: 0
+


### PR DESCRIPTION
It must be explicitly written as 0 so that all reviewers is specified.
(Example: https://github.com/planetarium/auto-assign-test#2)

Reference: https://github.com/kentaro-m/auto-assign#single-reviewers-list