### PR TITLE
Display hex values with monospace font

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -36,3 +36,7 @@ h1 {
 .ms-Link {
   font-family: 'Consolas', monospace;
 }
+
+code {
+  font-family: 'Consolas', monospace;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -32,3 +32,7 @@ h1 {
 .nav {
   margin-bottom: 10px;
 }
+
+.ms-Link {
+  font-family: 'Consolas', monospace;
+}


### PR DESCRIPTION
I added monospace font-style to link in Account Details page and codes in Transaction Details page.

<img width="737" alt="account_details" src="https://user-images.githubusercontent.com/56826914/92461045-b2fd7480-f203-11ea-998b-92083bdab5a2.png">
<img width="695" alt="transaction_details" src="https://user-images.githubusercontent.com/56826914/92461048-b4c73800-f203-11ea-8e0f-30303dce2399.png">

 close #115 