### PR TITLE
feat(tx-page): provide block reference field

### DIFF
--- a/src/api.graphql
+++ b/src/api.graphql
@@ -85,6 +85,9 @@ query TransactionById($id: ID) {
   transactionQuery {
     transaction(id: $id) {
       ...TransactionCommon
+      blockRef {
+        ...BlockCommon
+      }
     }
   }
 }

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -80,6 +80,7 @@ scalar Seconds
 
 type Transaction {
   actions: [Action!]!
+  blockRef: [Block!]
   id: ID!
   nonce: Int!
   publicKey: ByteString!

--- a/src/subpages/transaction.tsx
+++ b/src/subpages/transaction.tsx
@@ -41,6 +41,17 @@ const TransactionPage: React.FC<TransactionPageProps> = ({ location }) => {
               </p>
             </>
           );
+
+        const blockRef =
+          transaction.blockRef === [] || transaction.blockRef === null
+            ? (<p>{"No block references were found."}</p>)
+            : transaction.blockRef.map((block, index) => (
+              <dd key={index}>
+                <Link href={`../block/?${block.hash}`}>
+                  {block.hash}
+                </Link>
+              </dd>
+            ));
         // FIXME: We'd better to use absolute paths and make Gatsby to
         // automatically rebase these absolute paths on the PATH_PREFIX
         // configuration.
@@ -86,6 +97,8 @@ const TransactionPage: React.FC<TransactionPageProps> = ({ location }) => {
                   </Link>
                 </dd>
               ))}
+              <dt>Block Reference</dt>
+              {blockRef}
               <dt>Actions</dt>
               {transaction.actions.map((action, index) => (
                 <dd key={index}>


### PR DESCRIPTION
It provides the view for the `blockRef` field of the `Transaction` type.
If the transaction had contained in many blocks, then it will show all the blocks.

But sadly, planetarium/libplanet-explorer has many issues and the explorer in 9c-main doesn't work well for the `blockRef` field. This pull request should be merged after the issues fixed.

PS. The below screenshot has taken in my local environment.

![image](https://user-images.githubusercontent.com/26626194/97533734-1766d400-19fc-11eb-9bfc-12404f92e10a.png)
