### PR TITLE
update correct paths on account page

### DIFF
--- a/src/misc/columns.tsx
+++ b/src/misc/columns.tsx
@@ -10,7 +10,7 @@ export const commonProps = {
   isSorted: false,
 };
 
-export const mineColumns = [
+export const mainMineColumns = [
   {
     key: 'columnIndex',
     name: 'Index',
@@ -63,6 +63,87 @@ export const mineColumns = [
     isPadded: true,
     onRender: ({ miner }: Block) => (
       <Link href={`./account/?${miner}`}>{miner}</Link>
+    ),
+  },
+  {
+    key: 'columnDifficulty',
+    name: 'Difficulty',
+    minWidth: 50,
+    maxWidth: 200,
+    ...commonProps,
+    isSortedDescending: true,
+    data: 'string',
+    isPadded: true,
+    onRender: ({ difficulty }: Block) => (
+      <>{Math.floor(difficulty).toLocaleString()}</>
+    ),
+  },
+  {
+    key: 'columnTxNumber',
+    name: 'Tx #',
+    minWidth: 5,
+    maxWidth: 40,
+    ...commonProps,
+    isSortedDescending: false,
+    data: 'number',
+    isPadded: true,
+    onRender: ({ transactions }: Block) => <>{transactions.length}</>,
+  },
+];
+
+export const accountMineColumns = [
+  {
+    key: 'columnIndex',
+    name: 'Index',
+    fieldName: 'index',
+    iconName: 'NumberSymbol',
+    isIconOnly: true,
+    minWidth: 5,
+    maxWidth: 50,
+    ...commonProps,
+    isSortedDescending: true,
+    data: 'string',
+    isPadded: true,
+    onRender: ({ index }: Block) => <>{Number(index).toLocaleString()}</>,
+  },
+  {
+    key: 'columnHash',
+    name: 'Block Hash',
+    fieldName: 'hash',
+    minWidth: 5,
+    maxWidth: 450,
+    ...commonProps,
+    isSortedDescending: false,
+    data: 'string',
+    isPadded: true,
+    onRender: ({ hash }: Block) => (
+      <Link href={`../block/?${hash}`}>{hash}</Link>
+    ),
+  },
+  {
+    key: 'columnTimestamp',
+    name: 'Timestamp',
+    fieldName: 'timestamp',
+    minWidth: 100,
+    maxWidth: 200,
+    ...commonProps,
+    isSortedDescending: true,
+    data: 'string',
+    isPadded: true,
+    onRender: ({ timestamp }: Block) => <Timestamp timestamp={timestamp} />,
+  },
+  {
+    key: 'columnMiner',
+    name: 'MinerX',
+    fieldName: 'miner',
+    minWidth: 123,
+    maxWidth: 450,
+    ...commonProps,
+    isSortedDescending: true,
+    data: 'string',
+    isPadded: true,
+    onRender: ({ miner }: Block) => (
+      <Link href={`../account/?${miner}`}>{miner}</Link>
     ),
   },
   {

--- a/src/subpages/account.tsx
+++ b/src/subpages/account.tsx
@@ -18,7 +18,7 @@ import { IndexPageProps } from '../pages';
 
 import useQueryString from '../misc/useQueryString';
 import useOffset, { limit } from '../misc/useOffset';
-import { mineColumns, txColumns } from '../misc/columns';
+import { accountMineColumns, txColumns } from '../misc/columns';
 
 import styled from '@emotion/styled';
 
@@ -168,7 +168,7 @@ const AccountPage: React.FC<AccountPageProps> = ({ location }) => {
               <BlockList
                 blocks={blocks}
                 loading={loading}
-                columns={mineColumns}
+                columns={accountMineColumns}
               />
             </>
           );
@@ -247,7 +247,10 @@ const BlockList: React.FC<BlockListProps> = ({ blocks, ...props }) => (
   />
 );
 
-function splitTransactions(transactions: TransactionCommonFragment[], hash: string) {
+function splitTransactions(
+  transactions: TransactionCommonFragment[],
+  hash: string
+) {
   const signedTransactions: TransactionCommonFragment[] = [],
     involvedTransactions: TransactionCommonFragment[] = [];
   transactions.forEach(tx => {

--- a/src/subpages/list.tsx
+++ b/src/subpages/list.tsx
@@ -6,7 +6,7 @@ import { Checkbox, IColumn } from '@fluentui/react';
 import { Block, BlockListComponent } from '../generated/graphql';
 
 import useOffset, { limit } from '../misc/useOffset';
-import { mineColumns, commonProps } from '../misc/columns';
+import { mainMineColumns, commonProps } from '../misc/columns';
 
 import List, { BlockListProps } from '../components/List';
 import OffsetSwitch from '../components/OffsetSwitch';
@@ -27,8 +27,9 @@ const ListPage: React.FC<ListPageProps> = ({ location }) => {
         checked={excludeEmptyTxs}
         onChange={() => setExcludeEmptyTxs(!excludeEmptyTxs)}
       />
-      <BlockListComponent variables={{ offset, limit, excludeEmptyTxs }}
-                          pollInterval={POLL_INTERVAL}>
+      <BlockListComponent
+        variables={{ offset, limit, excludeEmptyTxs }}
+        pollInterval={POLL_INTERVAL}>
         {({ data, loading, error }) => {
           if (error) {
             console.error(error);
@@ -50,7 +51,7 @@ const ListPage: React.FC<ListPageProps> = ({ location }) => {
               <BlockList
                 blocks={blocks}
                 loading={loading}
-                columns={mineColumns}
+                columns={mainMineColumns}
               />
             </>
           );


### PR DESCRIPTION
The miner links on both the Main page and the Account page used the same "mineColumns" prop and this caused the miner link in the account page to go to '.../account/account/...' which does not exist.

There might be a more efficient way to do this but I created a separate prop for the accounts page and now the relative path will correctly navigate. Let me know if there are other ways to make this fix more efficient!