### PR TITLE
Feature/fix time taken

### DIFF
--- a/src/api.graphql
+++ b/src/api.graphql
@@ -31,6 +31,9 @@ query BlockList(
     ) {
       ...BlockCommon
       miner
+      previousBlock {
+        timestamp
+      }
       transactions {
         id
       }

--- a/src/misc/columns.tsx
+++ b/src/misc/columns.tsx
@@ -151,7 +151,7 @@ export const accountMineColumns = [
   },
   {
     key: 'columnMiner',
-    name: 'MinerX',
+    name: 'Miner',
     fieldName: 'miner',
     minWidth: 123,
     maxWidth: 450,

--- a/src/misc/columns.tsx
+++ b/src/misc/columns.tsx
@@ -79,6 +79,23 @@ export const mainMineColumns = [
     ),
   },
   {
+    key: 'columnTimeTaken',
+    name: 'Time Taken',
+    minWidth: 50,
+    maxWidth: 200,
+    ...commonProps,
+    data: 'string',
+    isPadded: true,
+    onRender: ({ timestamp, previousBlock }: Block) => {
+      if (previousBlock === null || previousBlock === undefined) {
+        return <>{0}</>;
+      }
+      const beforeTimestamp = Date.parse(previousBlock.timestamp);
+      const nowTimestamp = Date.parse(timestamp);
+      return <>{(nowTimestamp - beforeTimestamp) / 1000}</>;
+    },
+  },
+  {
     key: 'columnTxNumber',
     name: 'Tx #',
     minWidth: 5,
@@ -158,6 +175,23 @@ export const accountMineColumns = [
     onRender: ({ difficulty }: Block) => (
       <>{Math.floor(difficulty).toLocaleString()}</>
     ),
+  },
+  {
+    key: 'columnTimeTaken',
+    name: 'Time Taken',
+    minWidth: 50,
+    maxWidth: 200,
+    ...commonProps,
+    data: 'string',
+    isPadded: true,
+    onRender: ({ timestamp, previousBlock }: Block) => {
+      if (previousBlock === null || previousBlock === undefined) {
+        return <>{0}</>;
+      }
+      const beforeTimestamp = Date.parse(previousBlock.timestamp);
+      const nowTimestamp = Date.parse(timestamp);
+      return <>{(nowTimestamp - beforeTimestamp) / 1000}</>;
+    },
   },
   {
     key: 'columnTxNumber',

--- a/src/subpages/list.tsx
+++ b/src/subpages/list.tsx
@@ -122,26 +122,6 @@ const Cards: React.FC<CardsProps> = ({
 );
 
 const BlockList: React.FC<BlockListProps> = ({ blocks, loading, columns }) => {
-  const timeTaken: IColumn = {
-    key: 'columnTimeTaken',
-    name: 'Time Taken',
-    minWidth: 50,
-    maxWidth: 200,
-    ...commonProps,
-    isSortedDescending: true,
-    data: 'string',
-    isPadded: true,
-    onRender: (block: Block, index) => {
-      if (blocks === null) throw Error('blocks is null');
-      if (index === undefined) throw Error('index is null');
-      const beforeBlock = blocks[Math.min(index + 1, blocks.length - 1)];
-      const beforeTimestamp = Date.parse(beforeBlock.timestamp);
-      const nowTimestamp = Date.parse(block.timestamp);
-      return <>{(nowTimestamp - beforeTimestamp) / 1000}</>;
-    },
-  };
-
-  if (blocks !== null) columns.splice(4, 1, timeTaken);
   return (
     <List
       items={blocks}

--- a/src/subpages/list.tsx
+++ b/src/subpages/list.tsx
@@ -1,12 +1,12 @@
 import React, { useState } from 'react';
 import { navigate } from 'gatsby';
 
-import { Checkbox, IColumn } from '@fluentui/react';
+import { Checkbox } from '@fluentui/react';
 
 import { Block, BlockListComponent } from '../generated/graphql';
 
 import useOffset, { limit } from '../misc/useOffset';
-import { mainMineColumns, commonProps } from '../misc/columns';
+import { mainMineColumns } from '../misc/columns';
 
 import List, { BlockListProps } from '../components/List';
 import OffsetSwitch from '../components/OffsetSwitch';


### PR DESCRIPTION
This PR takes the previous "time taken" rendering code and adds it to the columns prop so that all blocks will show the relative time-taken anywhere on the page (originally, the "time taken" column was only shown at the initial loading of the main page).

In order to enable this feature, the graphql **query for "BlockList"** was modified to query the **"timestamp" of the "previousBlock"** to calculate the time-taken. This addition doesn't affect the query time much.