### PR TITLE
modify transactions count query

### DIFF
--- a/src/subpages/account.tsx
+++ b/src/subpages/account.tsx
@@ -47,7 +47,8 @@ const AccountPage: React.FC<AccountPageProps> = ({ location }) => {
 
       <h2>Transactions count</h2>
 
-      <TransactionsByAccountComponent variables={{ involvedAddress: hash }}>
+      <TransactionsByAccountComponent
+        variables={{ offset: txOffset, limit: 101, involvedAddress: hash }}>
         {({ data, loading, error }) => {
           if (error) {
             console.error(error);
@@ -78,9 +79,22 @@ const AccountPage: React.FC<AccountPageProps> = ({ location }) => {
 
           return (
             <Ul>
-              <li>Signed Transaction: {signedTransactions.length}</li>
-              <li>Involved Transaction: {involvedTransactions.length}</li>
-              <li>missingNonces: {missingNonces.length}</li>
+              <li>
+                Signed Transaction:{' '}
+                {signedTransactions.length === 101
+                  ? '100+'
+                  : signedTransactions.length}
+              </li>
+              <li>
+                Involved Transaction:{' '}
+                {involvedTransactions.length === 101
+                  ? '100+'
+                  : involvedTransactions.length}
+              </li>
+              <li>
+                missingNonces:{' '}
+                {missingNonces.length === 101 ? '100+' : missingNonces.length}
+              </li>
             </Ul>
           );
         }}


### PR DESCRIPTION
this PR temporarily modifies the query that originally requested all transactions to the most recent 101 transactions. If either "signed transactions", "involved transactions" or "missing nonces" are greater than 100, the count will render "100+".

**Note)** I found that the "desc" option in these queries almost doubles the response time so it might be a good place to look into for further optimization.

**Before:**
![Screen Shot 2020-11-26 at 12 36 43 PM](https://user-images.githubusercontent.com/42176649/100305296-2bdec200-2fe4-11eb-9e34-0cc72647c2d5.png)

**After:**
![Screen Shot 2020-11-26 at 12 33 26 PM](https://user-images.githubusercontent.com/42176649/100305314-339e6680-2fe4-11eb-9aed-a8e112759ed3.png)

