### PR TITLE
add test url

### DIFF
--- a/DEPLOYMENTS.tsv
+++ b/DEPLOYMENTS.tsv
@@ -1,5 +1,6 @@
 9c-internal	https://d3n1gito7w9cnj.cloudfront.net/graphql/
 9c-main	https://d131807iozwu1d.cloudfront.net/graphql/
+9c-main-test http://a802b7d8b04db41f89584959fb0d033c-293297671.us-east-2.elb.amazonaws.com:31235/graphql/
 9c-community-mining	https://d1h7rqqux58ljb.cloudfront.net/graphql/
-9c-contetn-rating	https://dblbss1cu65au.cloudfront.net/graphql/
+9c-content-rating	https://dblbss1cu65au.cloudfront.net/graphql/
 localhost	http://localhost:5000/graphql/


### PR DESCRIPTION
I'm adding a testing url for 9c-main to understand why the GraphQL upgrade version(https://github.com/planetarium/NineChronicles.Headless/tree/v100097-gql) of the headless won't load on the explorer as below.
![image](https://user-images.githubusercontent.com/42176649/147924150-2b764a85-26f9-43d9-9633-4323c8a023d5.png)
It's not an API type error because it works fine on the `https://d131807iozwu1d.cloudfront.net/ui/playground` endpoint and the console says that the error is from cloudfront. I've tried to reproduce the error on my local PC but it works fine, which is why I'm pretty sure it's a cloudfront-related issue. So I'm trying to bypass it by adding the load balancer url directly to further investigate the issue.