### PR TITLE
remove unnecessary url path

### DIFF
--- a/DEPLOYMENTS.tsv
+++ b/DEPLOYMENTS.tsv
@@ -1,6 +1,5 @@
-9c-internal	https://d3n1gito7w9cnj.cloudfront.net/graphql/
-9c-main	https://d131807iozwu1d.cloudfront.net/graphql/
-9c-main-test            http://a802b7d8b04db41f89584959fb0d033c-293297671.us-east-2.elb.amazonaws.com:31235/graphql/
-9c-community-mining	https://d1h7rqqux58ljb.cloudfront.net/graphql/
-9c-content-rating	https://dblbss1cu65au.cloudfront.net/graphql/
-localhost	http://localhost:5000/graphql/
+9c-internal	https://d3n1gito7w9cnj.cloudfront.net/graphql
+9c-main	https://d131807iozwu1d.cloudfront.net/graphql
+9c-community-mining	https://d1h7rqqux58ljb.cloudfront.net/graphql
+9c-content-rating	https://dblbss1cu65au.cloudfront.net/graphql
+localhost	http://localhost:5000/graphql


### PR DESCRIPTION
Removing the unnecessary `/` path at the end of the GraphQL endpoints because this seems to be the problem preventing the upgraded GQL headless data from being rendered on the frontend.

Error
![error](https://user-images.githubusercontent.com/42176649/148001035-1b3274f9-6ff1-416d-b6be-db6c199a76c9.png)

Fix
![fix](https://user-images.githubusercontent.com/42176649/148001046-8603d93d-7028-4248-961c-75cc5bfb2cf3.png)

