### PR TITLE
fix offset data type

### DIFF
--- a/src/misc/useOffset.ts
+++ b/src/misc/useOffset.ts
@@ -3,7 +3,7 @@ import useSearchParams from './useSearchParams';
 export const limit = 50;
 export default function useOffset(location: Location, keyName = 'offset') {
   const [searchParams, setSearchParams] = useSearchParams(location);
-  const offset = keyName in searchParams ? Number(searchParams[keyName]) : 0;
+  const offset = keyName in searchParams ? parseInt(searchParams[keyName]) : 0;
   const setOffset = (offset: number) => {
     if (offset < 1) {
       delete searchParams[keyName];

--- a/src/misc/useOffset.ts
+++ b/src/misc/useOffset.ts
@@ -3,7 +3,7 @@ import useSearchParams from './useSearchParams';
 export const limit = 50;
 export default function useOffset(location: Location, keyName = 'offset') {
   const [searchParams, setSearchParams] = useSearchParams(location);
-  const offset = keyName in searchParams ? searchParams[keyName] : 0;
+  const offset = keyName in searchParams ? Number(searchParams[keyName]) : 0;
   const setOffset = (offset: number) => {
     if (offset < 1) {
       delete searchParams[keyName];


### PR DESCRIPTION
This PR fixes the `{offset: "50", limit: 50, excludeEmptyTxs: false}` variable to `{offset: 50, limit: 50, excludeEmptyTxs: false}`.
This previously worked in the earlier GQL version but type enforcement became stricter in the new GQL so it returns an error.

Error example:
![offset_error](https://user-images.githubusercontent.com/42176649/148735823-e6fea057-cddc-4c3d-bf50-556fd031838c.PNG)